### PR TITLE
all: refactor to use composition and simplify state

### DIFF
--- a/read_closer_test.go
+++ b/read_closer_test.go
@@ -62,5 +62,9 @@ func TestReader(t *testing.T) {
 
 	<-done
 
-	defer rs.Close()
+	for i := 0; i < 10; i++ {
+		if err := rs.Close(); err != nil {
+			t.Errorf("#%d close err=%v", i, err)
+		}
+	}
 }

--- a/write_closer_test.go
+++ b/write_closer_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 )
 
-func producer(ws *WriteCloserStatos) chan bool {
+func producer(t *testing.T, ws *WriteCloserStatos) chan bool {
 	done := make(chan bool)
 
 	go func() {
@@ -28,7 +28,11 @@ func producer(ws *WriteCloserStatos) chan bool {
 			}
 		}
 
-		ws.Close()
+		for i := 0; i < 10; i++ {
+			if err := ws.Close(); err != nil {
+				t.Errorf("#%d close err=%v", i, err)
+			}
+		}
 		done <- true
 	}()
 
@@ -75,7 +79,7 @@ func TestWriteCloser(t *testing.T) {
 
 	ws := NewWriteCloser(destFile)
 
-	producerChan := producer(ws)
+	producerChan := producer(t, ws)
 	done := wProgresser(ws, producerChan)
 
 	<-done


### PR DESCRIPTION
Compose ReaderCloser from Reader, WriterCloser from Writer
to reuse a bunch of duplicated code and also fix up the
state management to avoid data races. Employing once
atomics and a RWMutex to avoid sending data on closed
channels since the main consumer of this project
drive makes asynchronous requests to each of the
objects and we've seen send on closed channels in the wild.

This commit is a long awaited fix-up that I hadn't
implemented due to lack of time, but alas the chickens
have come home to roost.